### PR TITLE
Use rate-limited streams for looking up block IDs

### DIFF
--- a/src/bin/twcc.rs
+++ b/src/bin/twcc.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<()> {
             Ok(())
         }
         SubCommand::ListBlocks(ListBlocks { ids_only }) => {
-            let ids = client.blocks().await?;
+            let ids: Vec<u64> = client.blocks_ids().try_collect::<Vec<_>>().await?;
             if ids_only {
                 for id in ids {
                     println!("{}", id);
@@ -120,7 +120,7 @@ async fn main() -> Result<()> {
             }
         }
         SubCommand::BlockedFollows(BlockedFollows { screen_name }) => {
-            let blocks = client.blocks().await?.into_iter().collect::<HashSet<u64>>();
+            let blocks = client.blocks_ids().try_collect::<HashSet<u64>>().await?;
             let blocked_friends = client
                 .followed_ids(screen_name.clone())
                 .try_collect::<Vec<_>>()
@@ -146,7 +146,7 @@ async fn main() -> Result<()> {
             Ok(())
         }
         SubCommand::FollowerReport(FollowerReport { screen_name }) => {
-            let blocks = client.blocks().await?.into_iter().collect::<HashSet<u64>>();
+            let blocks = client.blocks_ids().try_collect::<HashSet<u64>>().await?;
             let their_followers = client
                 .follower_ids(screen_name.clone())
                 .try_collect::<HashSet<u64>>()

--- a/src/twitter/method.rs
+++ b/src/twitter/method.rs
@@ -24,6 +24,7 @@ pub enum Method {
 }
 
 impl Method {
+    pub const USER_BLOCKS_IDS: &'static Method = &Method::User(UserMethod::BlocksIds);
     pub const USER_FOLLOWED_IDS: &'static Method = &Method::User(UserMethod::FriendsIds);
     pub const USER_FOLLOWER_IDS: &'static Method = &Method::User(UserMethod::FollowersIds);
     pub const USER_LOOKUP: &'static Method = &Method::User(UserMethod::Lookup);


### PR DESCRIPTION
After mass-blocking all of VDARE's followers it's now really easy for me to hit the rate limit here (currently 15 requests at 5,000 items each).