### PR TITLE
Support using CDX results from JSON file for deleted-tweets

### DIFF
--- a/src/twitter/error.rs
+++ b/src/twitter/error.rs
@@ -20,6 +20,8 @@ pub enum Error {
     HttpClientError(#[from] reqwest::Error),
     /// an error occurred when piloting the wayback machine subcrate: {0}
     WaybackClientError(#[from] crate::wayback::Error),
+    /// failure to read from CDX JSON file: {0}
+    CdxJsonError(#[source] std::io::Error),
     /// a failure occurred when parsing a tweet id string: {0}
     TweetIDParseError(String),
     /// the tweet ID {0}, which was supposed to be a reply, was not a reply

--- a/src/wayback/mod.rs
+++ b/src/wayback/mod.rs
@@ -115,13 +115,15 @@ impl Item {
     }
 
     fn from_row(row: &[String]) -> Result<Item> {
-        if row.len() != 5 {
+        if row.len() == 5 {
+            Item::parse(&row[0], &row[1], &row[2], &row[3], &row[4])
+        } else if row.len() == 6 {
+            Item::parse(&row[0], &row[1], &row[2], &row[3], &row[5])
+        } else {
             Err(Error::ItemParsingError(format!(
                 "Invalid item fields: {:?}",
                 row
             )))
-        } else {
-            Item::parse(&row[0], &row[1], &row[2], &row[3], &row[4])
         }
     }
 }


### PR DESCRIPTION
The current implementation can fail for accounts with large numbers of archived pages in the Wayback Machine. This change allows the CDX index results to be downloaded manually and provided as a file (via the new `--cdx` option).

You can download those results in the appropriate JSON format via a command like this:

```
wget "http://web.archive.org/cdx/search/cdx?url=https://twitter.com/JackPosobiec/*&output=json&fl=original,timestamp,digest,mimetype,length,statuscode
```

You can also page the results manually using the `showResumeKey` option.

In the slightly longer term we'll adjust the client here to do this paging for you, but this quick hack should help with large accounts in the short term.

Usage looks like this:

```
target/release/twcc -vvv deleted-tweets --cdx JackPosobiec-2021-09-26.json JackPosobiec
```

(I've also split up the tweet deletion checks, which should solve an unrelated problem.)