### PR TITLE
Flush loggers, etc.

### DIFF
--- a/src/bin/twcc.rs
+++ b/src/bin/twcc.rs
@@ -15,7 +15,7 @@ use std::io::Read;
 #[tokio::main]
 async fn main() -> Result<()> {
     let opts: Opts = Opts::parse();
-    let _ = cli::init_logging(opts.verbose);
+    let _ = cli::init_logging(opts.verbose).unwrap();
 
     let client = Client::from_config_file(&opts.key_file).await?;
 
@@ -471,6 +471,8 @@ async fn main() -> Result<()> {
                     }
                 }
             }
+
+            log::logger().flush();
 
             Ok(())
         }

--- a/src/bin/twcli.rs
+++ b/src/bin/twcli.rs
@@ -10,7 +10,7 @@ type Void = Result<(), Box<dyn std::error::Error>>;
 #[tokio::main]
 async fn main() -> Void {
     let opts: Opts = Opts::parse();
-    let _ = cli::init_logging(opts.verbose);
+    let _ = cli::init_logging(opts.verbose)?;
     let client = Client::from_config_file(&opts.key_file).await?;
 
     match opts.command {
@@ -111,6 +111,8 @@ async fn main() -> Void {
             .await?;
         }
     };
+
+    log::logger().flush();
 
     Ok(())
 }

--- a/src/bin/twdl.rs
+++ b/src/bin/twdl.rs
@@ -13,7 +13,7 @@ type Void = Result<(), Box<dyn std::error::Error>>;
 #[tokio::main]
 async fn main() -> Void {
     let opts: Opts = Opts::parse();
-    let _ = cli::init_logging(opts.verbose);
+    let _ = cli::init_logging(opts.verbose)?;
     let client = Client::from_config_file(&opts.key_file).await?;
     let store = Store::new(Connection::open(&opts.db_file)?);
 
@@ -48,6 +48,8 @@ async fn main() -> Void {
             store.add_users(&users)?;
         },
     };
+
+    log::logger().flush();
 
     Ok(())
 }

--- a/src/bin/twsearch.rs
+++ b/src/bin/twsearch.rs
@@ -4,7 +4,7 @@ use clap::{crate_authors, crate_version, Clap};
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let opts: Opts = Opts::parse();
-    let _ = cli::init_logging(opts.verbose);
+    let _ = cli::init_logging(opts.verbose)?;
 
     let mut browser = make_client_or_panic(
         &opts.browser,
@@ -26,6 +26,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     for id in ids {
         println!("{}", id);
     }
+
+    log::logger().flush();
 
     Ok(())
 }

--- a/src/bin/wbmc.rs
+++ b/src/bin/wbmc.rs
@@ -8,7 +8,7 @@ type Void = Result<(), Box<dyn std::error::Error>>;
 #[tokio::main]
 async fn main() -> Void {
     let opts: Opts = Opts::parse();
-    let _ = cli::init_logging(opts.verbose);
+    let _ = cli::init_logging(opts.verbose)?;
 
     match opts.command {
         SubCommand::Count { file, screen_name } => {
@@ -30,6 +30,8 @@ async fn main() -> Void {
             println!("{}", count);
         }
     }
+
+    log::logger().flush();
 
     Ok(())
 }

--- a/src/bin/wbmd.rs
+++ b/src/bin/wbmd.rs
@@ -12,7 +12,7 @@ type Void = Result<(), Box<dyn std::error::Error>>;
 async fn main() -> Void {
     //valid::Result<()> {
     let opts: Opts = Opts::parse();
-    let _ = cli::init_logging(opts.verbose);
+    let _ = cli::init_logging(opts.verbose)?;
 
     match opts.command {
         SubCommand::Create { dir } => {
@@ -226,6 +226,8 @@ async fn main() -> Void {
             }
         }
     }
+
+    log::logger().flush();
 
     Ok(())
 }

--- a/src/bin/wbparse.rs
+++ b/src/bin/wbparse.rs
@@ -12,7 +12,7 @@ type Void = Result<(), Box<dyn std::error::Error>>;
 #[tokio::main]
 async fn main() -> Void {
     let args: Vec<String> = std::env::args().collect();
-    let _ = cli::init_logging(3);
+    let _ = cli::init_logging(3)?;
     let path = Path::new(&args[1]);
     let store = Store::load("wayback")?;
 
@@ -73,6 +73,8 @@ async fn main() -> Void {
 
         log::info!("Parsed {} files", count);
     }
+
+    log::logger().flush();
 
     Ok(())
 }

--- a/src/bin/wbsave.rs
+++ b/src/bin/wbsave.rs
@@ -7,7 +7,7 @@ type Void = Result<(), Box<dyn std::error::Error>>;
 #[tokio::main]
 async fn main() -> Void {
     let opts: Opts = Opts::parse();
-    let _ = cli::init_logging(opts.verbose);
+    let _ = cli::init_logging(opts.verbose)?;
 
     let fantoccini_client = cancel_culture::browser::make_client_or_panic(
         &opts.browser,
@@ -29,6 +29,8 @@ async fn main() -> Void {
         let saved_url = client.save(&url).await?;
         println!("{}", saved_url);
     }
+
+    log::logger().flush();
 
     Ok(())
 }

--- a/src/bin/wbstore.rs
+++ b/src/bin/wbstore.rs
@@ -12,7 +12,7 @@ use std::io::BufRead;
 #[tokio::main]
 async fn main() -> Result<()> {
     let opts: Opts = Opts::parse();
-    let _ = cli::init_logging(opts.verbose);
+    let _ = cli::init_logging(opts.verbose).unwrap();
 
     let store = Store::load(opts.store_dir)?;
 
@@ -329,6 +329,8 @@ async fn main() -> Result<()> {
                 .await;
         }
     }
+
+    log::logger().flush();
 
     Ok(())
 }

--- a/src/bin/wbtweets.rs
+++ b/src/bin/wbtweets.rs
@@ -6,12 +6,16 @@ type Void = Result<(), Box<dyn std::error::Error>>;
 #[tokio::main]
 async fn main() -> Void {
     let opts: Opts = Opts::parse();
-    let _ = cli::init_logging(opts.verbose);
+    let _ = cli::init_logging(opts.verbose)?;
 
     let store = Store::load(opts.store_dir)?;
     let tweet_store = TweetStore::new(opts.db, opts.clean)?;
 
-    Ok(store.export_tweets(&tweet_store).await?)
+    store.export_tweets(&tweet_store).await?;
+
+    log::logger().flush();
+
+    Ok(())
 }
 
 #[derive(Clap)]

--- a/src/bin/wbvalidate.rs
+++ b/src/bin/wbvalidate.rs
@@ -14,7 +14,7 @@ type Void = Result<(), Box<dyn std::error::Error>>;
 #[tokio::main]
 async fn main() -> Void {
     let opts: Opts = Opts::parse();
-    let _ = cli::init_logging(opts.verbose);
+    let _ = cli::init_logging(opts.verbose)?;
 
     let store = Store::load(opts.store_dir)?;
     let query = opts.query.unwrap_or_else(|| "".to_string());
@@ -65,6 +65,8 @@ async fn main() -> Void {
             }
         }
     }
+
+    log::logger().flush();
 
     Ok(())
 }


### PR DESCRIPTION
The [new 0.10.1 release](https://github.com/Drakulix/simplelog.rs/releases/tag/v0.10.1) of simplelog buffers console output by default. We don't really need buffering for the sake of performance, and could probably switch to a non-buffering writer, but for now I just flush the logger at the end of each program. I've also made initialization failure (which seems pretty unlikely) fail fast.