### PR TITLE
Add whitespace to TOML example

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,10 @@ for your Twitter account, and you'll need to provide the necessary keys in a fil
 
 ```toml
 [twitter]
-consumerKey="****"
-consumerSecret="****"
-accessToken="****"
-accessTokenSecret="****"
+consumerKey = "****"
+consumerSecret = "****"
+accessToken = "****"
+accessTokenSecret = "****"
 ```
 
 Some of the other tools require a [WebDriver](https://www.w3.org/TR/webdriver/) server instead of


### PR DESCRIPTION
Resolves #33. I don't think TOML should technically require spaces here, but it's more idiomatic anyway, so if it seems to be causing issues let's just change it.