### PR TITLE
Add simple tool for processing status availability files

### DIFF
--- a/src/bin/availability.rs
+++ b/src/bin/availability.rs
@@ -1,0 +1,52 @@
+use std::collections::HashMap;
+use std::fs;
+use std::io::{BufRead, BufReader};
+
+type Void = Result<(), Box<dyn std::error::Error>>;
+
+/// Iterate over all files indicating tweet availability in a directory and output the most recent
+/// availability status for each tweet. Expected format is a two-column CSV file with tweet ID and
+/// either a 0 or 1 indicating availability (where 0 means unavailable).
+fn main() -> Void {
+    let args = std::env::args().collect::<Vec<_>>();
+    let mut entries = fs::read_dir(&args[1])
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()?;
+    entries.sort_by_key(|entry| entry.path());
+
+    let mut availability = HashMap::new();
+
+    for entry in entries {
+        let reader = BufReader::new(fs::File::open(entry.path())?);
+        for res in reader.lines() {
+            let line = res?;
+            let mut fields = line.split(",").map(|field| field.trim());
+
+            let tweet_id = fields
+                .next()
+                .expect("Invalid format: no tweet ID")
+                .parse::<u64>()
+                .expect("Invalid format: bad tweet ID");
+            let availability_code = fields
+                .next()
+                .expect("Invalid format: no availability")
+                .parse::<usize>()
+                .expect("Invalid format: bad availability");
+
+            if availability_code != 0 && availability_code != 1 {
+                panic!("Invalid format: bad availability");
+            }
+
+            availability.insert(tweet_id, availability_code == 1);
+        }
+    }
+
+    let mut pairs = availability.into_iter().collect::<Vec<_>>();
+    pairs.sort();
+
+    for (tweet_id, is_available) in pairs {
+        println!("{},{}", tweet_id, if is_available { "1" } else { "0" });
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
The `twcc check-existence` tool takes as input a list of tweet IDs on standard input and outputs a CSV file like this, where `0` indicates that the tweet is unavailable (either deleted or from a suspended or locked account) and `1` indicates that it's live:

```
9142291,1
10643701,1
18984851,1
34661512,1
48826972,1
72706082,1
75507232,1
102425362,0
119141862,1
120506682,0
```

We've published this output for large batches of tweet IDs at `s3://twitter-metadata/status-availability/`. The output there includes rechecks, where we check the same IDs multiple times (to get a fresh view after months, etc.).

It can be useful to combine these results into a single list that indicates the most recently known status for each tweet ID, which is what this tool does. You point it to a directory of CSV files like the example above, where the filenames correspond to chronological order, and it outputs a sorted list of each unique tweet ID and its most recent status.

Note that it takes about four minutes to run on our current availability files (representing a hundred-million-ish tweets and retweets, most of which have been checked at least twice).